### PR TITLE
Remove unused parameter

### DIFF
--- a/src/MP4Box/MP4Box.php
+++ b/src/MP4Box/MP4Box.php
@@ -62,7 +62,7 @@ class MP4Box
         return $this;
     }
 
-    public function process($outPathfile = null, Array $options = null)
+    public function process($outPathfile = null)
     {
         if (!$this->pathfile) {
             throw new LogicException('No file open');


### PR DESCRIPTION
The $options parameter is never used in the process() method.
